### PR TITLE
Fix problem in publish pipeline action

### DIFF
--- a/extra/actions/publish-typescript-client/action.yaml
+++ b/extra/actions/publish-typescript-client/action.yaml
@@ -19,7 +19,7 @@ runs:
         yarn config set npmScopes.navikt.npmRegistryServer "https://npm.pkg.github.com"
         yarn config set npmScopes.navikt.npmAlwaysAuth true
         yarn config set npmScopes.navikt.npmAuthToken $NODE_AUTH_TOKEN
-        yarn install --immutable-cache
+        yarn install
         yarn npm publish
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' # yarn install must fill inn the boilerplate needed for yarn publish.


### PR DESCRIPTION
yarn install without --immutable-cache in publish action.

Otherwise yarn fails, since it now needs to resolve the @hey-api dependency that is not really installed by the generator.