### PR TITLE
Legg til sif-code-scan i CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,5 +84,6 @@ jobs:
   sif-code-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,8 @@ jobs:
 
 
   sif-code-scan:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,5 +85,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@v1
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,3 +80,9 @@ jobs:
           push-image: true
           image_suffix: '-cli'
 
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main


### PR DESCRIPTION
Legger til sif-code-scan som en parallell jobb i CI-workflowen. Denne sjekker koden for sensitive data som fødselsnummer.